### PR TITLE
Added SOES Etherberry demo switch

### DIFF
--- a/package/soes/Config.in
+++ b/package/soes/Config.in
@@ -9,5 +9,16 @@ config BR2_PACKAGE_SOES
 
           https://github.com/OpenEtherCATsociety/SOES
 
+if BR2_PACKAGE_SOES
+
+config BR2_PACKAGE_SOES_RPI_ETHERBERRY_DEMO
+	bool "Build RPI demo variant"
+	default n
+	help
+		Builds the IO demo variant for Raspberry pi with EtherBerry
+		Ethercat hat.
+
+endif # BR2_PACKAGE_SOES
+
 comment "SOES needs a Linux kernel to be built"
         depends on !BR2_LINUX_KERNEL

--- a/package/soes/soes.mk
+++ b/package/soes/soes.mk
@@ -10,10 +10,16 @@ SOES_INSTALL_STAGING = YES
 SOES_LICENSE = Licensed under the GNU General Public License version 2 with exceptions
 SOES_LICENSE_FILES = LICENSE
 SOES_SUPPORTS_IN_SOURCE_BUILD = NO
-SOES_CONF_OPTS = -DBUILD_SHARED_LIBS=OFF
+SOES_CONF_OPTS += -DBUILD_SHARED_LIBS=OFF
+SOES_CONF_OPTS += \
+	-DRPI_VARIANT=$(if $(BR2_PACKAGE_SOES_RPI_ETHERBERRY_DEMO),ON,OFF)
 
 SOES_MODULE_SUBDIRS = drivers/linux/lan9252
 SOES_MODULE_MAKE_OPTS = CONFIG_LAN9252=m CFLAGS_lan9252.o=-DDEBUG
+
+define SOES_PERMISSIONS
+	/etc/init.d/S60soes f 111 root root - - - - -
+endef
 
 $(eval $(kernel-module))
 $(eval $(cmake-package))


### PR DESCRIPTION
Added an option in the SOES package to set the "RPI_ETHERBERRY_DEMO" compile
flag, which will make SOES compile a demo for aforementioned dev board.