### PR TITLE
Replace Git protocol with HTTPS

### DIFF
--- a/package/c-open/c-open.mk
+++ b/package/c-open/c-open.mk
@@ -5,7 +5,8 @@
 ################################################################################
 
 C_OPEN_VERSION = 0d67a709c663d3a1f6a2d9be1d2ff6e508ead41f
-C_OPEN_SITE = git://github.com/rtlabs-com/c-open.git
+C_OPEN_SITE = https://github.com/rtlabs-com/c-open.git
+C_OPEN_SITE_METHOD = git
 C_OPEN_GIT_SUBMODULES = YES
 C_OPEN_INSTALL_STAGING = YES
 C_OPEN_LICENSE = Dual-licensed under GPLv3 or a commercial license

--- a/package/m-bus/m-bus.mk
+++ b/package/m-bus/m-bus.mk
@@ -5,7 +5,8 @@
 ################################################################################
 
 M_BUS_VERSION = c8193517d020fa1e701bbab4ee0220ef6e90445d
-M_BUS_SITE = git://github.com/rtlabs-com/m-bus.git
+M_BUS_SITE = https://github.com/rtlabs-com/m-bus.git
+M_BUS_SITE_METHOD = git
 M_BUS_GIT_SUBMODULES = YES
 M_BUS_INSTALL_STAGING = YES
 M_BUS_LICENSE = Dual-licensed under GPLv3 or a commercial license

--- a/package/p-net/p-net.mk
+++ b/package/p-net/p-net.mk
@@ -5,7 +5,8 @@
 ################################################################################
 
 P_NET_VERSION = 08abd0431c8bd236e9eabe304772bfd0449e49d4
-P_NET_SITE = git://github.com/rtlabs-com/p-net.git
+P_NET_SITE = https://github.com/rtlabs-com/p-net.git
+P_NET_SITE_METHOD = git
 P_NET_GIT_SUBMODULES = YES
 P_NET_INSTALL_STAGING = YES
 P_NET_LICENSE = Dual-licensed under GPLv3 or a commercial license


### PR DESCRIPTION
Packages c-open, m-bus and p-net were using unencrypted Git protocol for which GitHub dropped support at March 2022. These packages are now set to use HTTPS.